### PR TITLE
Add busted tests for JSON validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ https://callaway.smartthings.com/channels/31e1f421-55b7-4df3-9ca4-7f0ab93c927a
 Driver Model
 
 https://github.com/againtalent/SmartThings-Klipper
+
+## Running Tests
+
+This repository uses [busted](https://olivinelabs.com/busted/) to run Lua
+unit tests located in the `tests/` directory. To run the tests locally:
+
+```bash
+sudo apt-get update && sudo apt-get install -y luarocks
+sudo luarocks install busted
+busted tests
+```
+
+The test suite validates that project JSON files can be loaded with `dkjson`.

--- a/tests/json_validation_spec.lua
+++ b/tests/json_validation_spec.lua
@@ -1,0 +1,10 @@
+describe("JSON validation", function()
+  it("decodes capabilities/patchprepare64330.status.json", function()
+    local json = require "dkjson"
+    local file = assert(io.open("capabilities/patchprepare64330.status.json", "r"))
+    local content = file:read("*a")
+    file:close()
+    local obj, pos, err = json.decode(content, 1, nil)
+    assert.is_not_nil(obj, err or ("invalid json at pos " .. tostring(pos)))
+  end)
+end)


### PR DESCRIPTION
## Summary
- add a JSON decoding spec using `busted`
- document how to run the tests with `busted`

## Testing
- `busted tests`

------
https://chatgpt.com/codex/tasks/task_e_687576fdbaa48329bdc27a130fab80a1