### PR TITLE
Clean up driver comments

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -109,7 +109,7 @@ local function handle_refresh(driver, device)
 end
 
 -----------------------------------------------------------------
--- Definição e execução do driver
+-- Driver definition and execution
 -----------------------------------------------------------------
 
 local bambulab_driver = Driver("Bambu Lab", {
@@ -127,5 +127,5 @@ local bambulab_driver = Driver("Bambu Lab", {
   }
 })
 
--- CORREÇÃO FINAL: Use o nome correto do objeto do driver!
+-- Start the driver event loop
 bambulab_driver:run()


### PR DESCRIPTION
## Summary
- translate driver setup comments to English
- clarify when the driver event loop starts

## Testing
- `nl -ba src/init.lua | sed -n '110,131p'`

------
https://chatgpt.com/codex/tasks/task_e_687576fafdc8832994f91c96fadf227f