### PR TITLE
Fix discovery permissions in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,6 @@ packageKey: bambu-printer-simple
 description: Impressora BambuLab simples para SmartThings
 profiles:
   - singleBambuPrinter
+permissions:
+  lan: {}
+  discovery: {}


### PR DESCRIPTION
## Summary
- include required `lan` and `discovery` permissions in `config.yaml`

## Testing
- `busted -o gtest -v tests` *(fails: Cannot find file or directory: tests)*
- `sudo apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_6875992f005483298aa9257dd270428b