### PR TITLE
Atualiza preferencia de porta

### DIFF
--- a/profiles/singleBambuPrinter.yaml
+++ b/profiles/singleBambuPrinter.yaml
@@ -11,15 +11,15 @@ metadata:
   ocfDeviceType: oic.d.sensor
   deviceTypeId: singleBambuPrinter
 preferences:
-  - title: Nome da Impressora
-    name: printerName
+  - title: Porta
+    name: printerPort
     required: true
     preferenceType: string
     definition:
       stringType: text
       minLength: 1
-      maxLength: 32
-      default: "Minha Impressora"
+      maxLength: 5
+      default: "8883"
   - title: IP da Impressora
     name: printerIp
     required: true


### PR DESCRIPTION
## Summary
- update `singleBambuPrinter` profile to use printerPort preference instead of printerName

## Testing
- `busted -o gtest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_687660681f288329ac11ac96d865aca5