### PR TITLE
Add status and progress capabilities

### DIFF
--- a/capabilities/bambuPrinterProgress.yaml
+++ b/capabilities/bambuPrinterProgress.yaml
@@ -1,0 +1,13 @@
+id: custom.bambuPrinterProgress
+version: 1
+status: draft
+name: Bambu Printer Progress
+attributes:
+  progress:
+    schema:
+      type: number
+      minimum: 0
+      maximum: 100
+      unit: '%'
+    required: true
+commands: {}

--- a/capabilities/bambuPrinterStatus.yaml
+++ b/capabilities/bambuPrinterStatus.yaml
@@ -1,0 +1,14 @@
+id: custom.bambuPrinterStatus
+version: 1
+status: draft
+name: Bambu Printer Status
+attributes:
+  printerStatus:
+    schema:
+      type: string
+      enum:
+        - printing
+        - pause
+        - stop
+    required: true
+commands: {}

--- a/profiles/singleBambuPrinter.yaml
+++ b/profiles/singleBambuPrinter.yaml
@@ -2,9 +2,9 @@ name: singleBambuPrinter
 components:
   - id: main
     capabilities:
-      - id: temperatureMeasurement
+      - id: custom.bambuPrinterStatus
         version: 1
-      - id: switch
+      - id: custom.bambuPrinterProgress
         version: 1
 metadata:
   deviceType: generic

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,5 +1,6 @@
 local Driver = require('st.driver')
 local log = require('log')
+local capabilities = require('st.capabilities')
 
 log.info(">>> Driver Edge BambuLab foi carregado e está aguardando discovery...")
 
@@ -27,6 +28,10 @@ local function added_handler(driver, device)
   device:set_field("ip", ip, {persist = true})
 
   log.info(string.format(">>> Campos iniciais setados: status=%s, ip=%s", status, ip))
+
+  -- initialize capability values
+  device:emit_event(capabilities["custom.bambuPrinterStatus"].printerStatus("stop"))
+  device:emit_event(capabilities["custom.bambuPrinterProgress"].progress(0))
 end
 
 local driver = Driver("bambu-printer-simple", {


### PR DESCRIPTION
## Summary
- add custom capabilities for printer status and progress
- update device profile to expose the new capabilities
- send initial events for status and progress when the device is added

## Testing
- `busted -o gtest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6876613006e88329add5a29a47c9bfa7