### PR TITLE
Switch to patchprepare capability IDs

### DIFF
--- a/capabilities/bambuPrinterProgress.yaml
+++ b/capabilities/bambuPrinterProgress.yaml
@@ -1,4 +1,4 @@
-id: custom.bambuPrinterProgress
+id: patchprepare64330.printProgress
 version: 1
 status: draft
 name: Bambu Printer Progress

--- a/capabilities/bambuPrinterStatus.yaml
+++ b/capabilities/bambuPrinterStatus.yaml
@@ -1,4 +1,4 @@
-id: custom.bambuPrinterStatus
+id: patchprepare64330.status
 version: 1
 status: draft
 name: Bambu Printer Status

--- a/profiles/singleBambuPrinter.yaml
+++ b/profiles/singleBambuPrinter.yaml
@@ -2,9 +2,9 @@ name: singleBambuPrinter
 components:
   - id: main
     capabilities:
-      - id: custom.bambuPrinterStatus
+      - id: patchprepare64330.status
         version: 1
-      - id: custom.bambuPrinterProgress
+      - id: patchprepare64330.printProgress
         version: 1
 metadata:
   deviceType: generic

--- a/src/init.lua
+++ b/src/init.lua
@@ -30,8 +30,8 @@ local function added_handler(driver, device)
   log.info(string.format(">>> Campos iniciais setados: status=%s, ip=%s", status, ip))
 
   -- initialize capability values
-  device:emit_event(capabilities["custom.bambuPrinterStatus"].printerStatus("stop"))
-  device:emit_event(capabilities["custom.bambuPrinterProgress"].progress(0))
+  device:emit_event(capabilities["patchprepare64330.status"].printerStatus("stop"))
+  device:emit_event(capabilities["patchprepare64330.printProgress"].progress(0))
 end
 
 local driver = Driver("bambu-printer-simple", {


### PR DESCRIPTION
## Summary
- update the capability YAML to use `patchprepare64330` codes
- update profile and driver references

## Testing
- `busted -o gtest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_687665b46ecc832991b3c4066fa1ca18