### PR TITLE
Fix capability IDs

### DIFF
--- a/capabilities/patchprepare64330.message.json
+++ b/capabilities/patchprepare64330.message.json
@@ -1,5 +1,5 @@
 {
-    "id": "patchprepare64330.bambuPrinterMessage",
+    "id": "patchprepare64330.message",
     "version": 1,
     "status": "proposed",
     "name": "message",

--- a/capabilities/patchprepare64330.printerProgress.json
+++ b/capabilities/patchprepare64330.printerProgress.json
@@ -1,5 +1,5 @@
 {
-    "id": "patchprepare64330.bambuPrinterProgress",
+    "id": "patchprepare64330.printerProgress",
     "version": 1,
     "status": "proposed",
     "name": "Printer Progress",

--- a/profiles/singleBambuPrinter.yaml
+++ b/profiles/singleBambuPrinter.yaml
@@ -4,9 +4,9 @@ components:
     capabilities:
       - id: patchprepare64330.bambuPrinterStatus
         version: 1
-      - id: patchprepare64330.bambuPrinterProgress
+      - id: patchprepare64330.printerProgress
         version: 1
-      - id: patchprepare64330.bambuPrinterMessage
+      - id: patchprepare64330.message
         version: 1
 metadata:
   deviceType: generic

--- a/src/init.lua
+++ b/src/init.lua
@@ -31,8 +31,8 @@ local function added_handler(driver, device)
 
   -- initialize capability values
   device:emit_event(capabilities["patchprepare64330.bambuPrinterStatus"].printerStatus("stop"))
-  device:emit_event(capabilities["patchprepare64330.bambuPrinterProgress"].progress(0))
-  device:emit_event(capabilities["patchprepare64330.bambuPrinterMessage"].progress(0))
+  device:emit_event(capabilities["patchprepare64330.printerProgress"].progress(0))
+  device:emit_event(capabilities["patchprepare64330.message"].message(""))
 
 end
 

--- a/tests/added_handler_spec.lua
+++ b/tests/added_handler_spec.lua
@@ -16,9 +16,14 @@ describe('added_handler', function()
         return {capability = 'status', value = value}
       end
     },
-    ["patchprepare64330.bambuPrinterProgress"] = {
+    ["patchprepare64330.printerProgress"] = {
       progress = function(value)
         return {capability = 'progress', value = value}
+      end
+    },
+    ["patchprepare64330.message"] = {
+      message = function(value)
+        return {capability = 'message', value = value}
       end
     }
   }
@@ -54,6 +59,8 @@ describe('added_handler', function()
     assert.equal('stop', dev.events[1].value)
     assert.equal('progress', dev.events[2].capability)
     assert.equal(0, dev.events[2].value)
+    assert.equal('message', dev.events[3].capability)
+    assert.equal('', dev.events[3].value)
   end)
 
   it('prefers stored ip from preferences', function()


### PR DESCRIPTION
## Summary
- rename custom capability files
- update profile and device init to use new capability IDs
- cover new message capability in test suite

## Testing
- `UNIT_TEST=1 busted -o gtest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6876e8c912808329b67c1339da939bc0