### PR TITLE
Fix packaging error due to default preference length

### DIFF
--- a/profiles/BambuPrinter.yaml
+++ b/profiles/BambuPrinter.yaml
@@ -34,13 +34,13 @@ preferences:
     definition:
       stringType: text
       maxLength: 8
-      default: "Access Code"
+      default: "00000000"
   - name: serialNumber
     title: "Serial Number"
     description: "Found on the printer's screen or in Bambu Studio."
     required: true
     preferenceType: string
     definition:
-      stringType: text
+      stringType: password
       maxLength: 15
       default: "Serial"


### PR DESCRIPTION
## Summary
- fix `accessCode` default value so it fits the declared max length
- update `serialNumber` preference to use password type so the user can enter up to 15 characters

## Testing
- `pip install pyyaml --quiet`
- `python - <<'PY' ...` (YAML parse)
- `busted -o gtest -v tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b96bf84f08329974bfc02f99f9b78