### PR TITLE
Fix MQTT host parsing

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -47,8 +47,11 @@ local function added_handler(driver, device)
 end
 
 local function connect_mqtt(driver, device)
-  local ip = device.preferences.printerIp:match("^%s*(.-)%s*$")
-  local port = device.preferences.printerPort
+  local ip = device.preferences.printerIp or ""
+  -- trim spaces and remove optional square brackets
+  ip = ip:match("^%s*(.-)%s*$"):gsub("[%[%]]", "")
+
+  local port = tostring(device.preferences.printerPort or ""):match("^%s*(.-)%s*$")
   local pass = device.preferences.accessCode
   local serial = device.preferences.serialNumber
 


### PR DESCRIPTION
## Summary
- parse `printerIp` to remove extra spaces or brackets

## Testing
- `UNIT_TEST=1 busted -o gtest -v tests` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd414685c832996e7602e7c572e61